### PR TITLE
Adding check for consul peers and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased][unreleased]
+### Added
+- Added check to alert on consul peer servers
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
 [![Codeship Status for sensu-plugins/sensu-plugins-consul](https://codeship.com/projects/c01130b0-cddd-0132-9d10-36838894891f/status?branch=master)](https://codeship.com/projects/76354)
 
 ## Files
- * bin/check-consul.rb
+ * bin/check-consul-failures.rb
+ * bin/check-consul-leader.rb
+ * bin/check-consul-servers.rb
  * bin/check-service-consul.rb
+
 
 ## Usage
 

--- a/bin/check-consul-servers.rb
+++ b/bin/check-consul-servers.rb
@@ -1,0 +1,77 @@
+#! /usr/bin/env ruby
+#
+#   check-consul-leader
+#
+# DESCRIPTION:
+#   This plugin checks if consul is up and reachable. It then checks
+#   the status/leader and ensures there is a current leader.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: diplomat
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Sonian, Inc. and contributors. <support@sensuapp.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+require 'json'
+
+#
+# Consul Status
+#
+class ConsulStatus < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'consul server',
+         short: '-s SERVER',
+         long: '--server SERVER',
+         default: '127.0.0.1'
+
+  option :port,
+         description: 'consul http port',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: '8500'
+
+  option :min,
+         description: 'minimum number of peers',
+         short: '-g GREATER THAN',
+         long: '--greater GREATER THAN',
+         default: 3
+
+  option :expected,
+         description: 'expected number of peers',
+         short: '-e EXPECT',
+         long: '--expect EXPECT',
+         default: 5
+
+  def run
+    json = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/v1/status/peers", timeout: 5).get
+    peers = JSON.parse(json).length.to_i
+    if peers <= config[:min]
+      critical "[#{peers}] peers is below critical threshold of [#{config[:min]}]"
+    elsif peers != config[:expected]
+      warning "[#{peers}] peers is outside of expected count of [#{config[:expected]}]"
+    else
+      ok 'Peers within threshold'
+    end
+  rescue Errno::ECONNREFUSED
+    critical 'Consul is not responding'
+  rescue RestClient::RequestTimeout
+    critical 'Consul Connection timed out'
+  end
+end


### PR DESCRIPTION
Warns when peers are not at the expected count.  Alerts when peers are below a certain threshold.
I chose the values of 3 and 5 per https://www.consul.io/docs/internals/consensus.html