### PR TITLE
Consul service check fixes

### DIFF
--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -77,8 +77,8 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
       } if d['Status'] == 'failing'
     end
     unknown "Could not find service - are there checks defined?" if failing.empty? and passing.empty?
-    critical message unless failing.empty?
-    ok unless passing.empty?
+    critical failing unless failing.empty?
+    ok passing unless passing.empty?
   end
 
 end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -76,9 +76,8 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
         'notes' => d['Notes']
       } if d['Status'] == 'failing'
     end
-    unknown "Could not find service - are there checks defined?" if failing.empty? and passing.empty?
+    unknown 'Could not find service - are there checks defined?' if failing.empty? && passing.empty?
     critical failing unless failing.empty?
     ok passing unless passing.empty?
   end
-
 end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -60,16 +60,25 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   #
   def run
     data = acquire_service_data
-    message = []
+    passing = []
+    failing = []
     data.each do |d|
-      message << {
+      passing << {
         'node' => d['Node'],
         'service' => d['ServiceName'],
         'service_id' => d['ServiceID'],
         'notes' => d['Notes']
-      } unless d['Status'] == 'passing'
+      } if d['Status'] == 'passing'
+      failing << {
+        'node' => d['Node'],
+        'service' => d['ServiceName'],
+        'service_id' => d['ServiceID'],
+        'notes' => d['Notes']
+      } if d['Status'] == 'failing'
     end
-    critical message unless message == '[]'
-    ok
+    unknown "Could not find service - are there checks defined?" if failing.empty? and passing.empty?
+    critical message unless failing.empty?
+    ok unless passing.empty?
   end
+
 end


### PR DESCRIPTION
- Defines two arrays instead of the single 'message' array - `passing` and `failing` 
- Operates on these arrays to determine whether the service is passing or failing
- this addresses #6 