### PR TITLE
Consul checks with UNKNOWN status should fail gracefully

### DIFF
--- a/bin/check-consul-failures.rb
+++ b/bin/check-consul-failures.rb
@@ -57,5 +57,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
       critical 'Consul is not responding'
     rescue RestClient::RequestTimeout
       critical 'Consul Connection timed out'
+    rescue RestClient::Exception => e
+      unknown "Consul returned: #{e}"
   end
 end

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -85,5 +85,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     critical 'Consul is not responding'
   rescue RestClient::RequestTimeout
     critical 'Consul Connection timed out'
+  rescue RestClient::Exception => e
+    unknown "Consul returned: #{e}"
   end
 end

--- a/bin/check-consul-servers.rb
+++ b/bin/check-consul-servers.rb
@@ -73,5 +73,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     critical 'Consul is not responding'
   rescue RestClient::RequestTimeout
     critical 'Consul Connection timed out'
+  rescue RestClient::Exception => e
+    unknown "Consul returned: #{e}"
   end
 end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -49,17 +49,15 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Get the check data for the service from consul
   #
   def acquire_service_data
-    begin
-      if config[:all]
-        Diplomat::Health.checks
-      else
-        Diplomat::Health.checks(config[:service])
-      end
-    rescue Faraday::ConnectionFailed => e
-      warning "Connection error occurred: #{e}"
-    rescue StandardError => e
-      unknown "Exception occurred when checking consul service: #{e}"
+    if config[:all]
+      Diplomat::Health.checks
+    else
+      Diplomat::Health.checks(config[:service])
     end
+  rescue Faraday::ConnectionFailed => e
+    warning "Connection error occurred: #{e}"
+  rescue StandardError => e
+    unknown "Exception occurred when checking consul service: #{e}"
   end
 
   # Main function

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -49,10 +49,16 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Get the check data for the service from consul
   #
   def acquire_service_data
-    if config[:all]
-      Diplomat::Health.checks
-    else
-      Diplomat::Health.checks(config[:service])
+    begin
+      if config[:all]
+        Diplomat::Health.checks
+      else
+        Diplomat::Health.checks(config[:service])
+      end
+    rescue Faraday::ConnectionFailed => e
+      warning "Connection error occurred: #{e}"
+    rescue StandardError => e
+      unknown "Exception occurred when checking consul service: #{e}"
     end
   end
 


### PR DESCRIPTION
This change catches exceptions which would usually cause CRITICAL errors