### PR TITLE
adding check-consul-members.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- Nothing
+- Added check to alert on consul cluster members, supports querying wan members @aianchici
 
 ## [0.0.7] - 2015-11-12
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
  * bin/check-consul-failures.rb
  * bin/check-consul-leader.rb
  * bin/check-consul-servers.rb
+ * bin/check-consul-members.rb
  * bin/check-service-consul.rb
 
 ## Usage

--- a/bin/check-consul-members.rb
+++ b/bin/check-consul-members.rb
@@ -76,7 +76,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     members = JSON.parse(json)
     members.each do |member|
       # only count the member if its status is alive
-      if member['Status'] == 1
+      if member.key?('Tags') && member['Tags']['role'] == 'consul' && member['Status'] == 1
         peers += 1
       end
     end

--- a/bin/check-consul-members.rb
+++ b/bin/check-consul-members.rb
@@ -1,10 +1,11 @@
 #! /usr/bin/env ruby
 #
-#   check-consul-servers
+#   check-consul-members
 #
 # DESCRIPTION:
 #   This plugin checks if consul is up and reachable. It then checks
-#   the number of peers matches the excepted value
+#   the status of the members of the cluster to determine if the correct
+#   number of peers are reporting as 'alive'
 #
 # OUTPUT:
 #   plain text
@@ -59,9 +60,27 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          long: '--expect EXPECT',
          default: 5
 
+  option :wan,
+         description: 'whether to check the wan members',
+         short: '-w',
+         long: '--wan',
+         boolean: false
+
   def run
-    json = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/v1/status/peers", timeout: 5).get
-    peers = JSON.parse(json).length.to_i
+    url = "http://#{config[:server]}:#{config[:port]}/v1/agent/members"
+    if config[:wan]
+      url += '?wan=1'
+    end
+    json = RestClient::Resource.new(url, timeout: 5).get
+    peers = 0
+    members = JSON.parse(json)
+    members.each do |member|
+      # only count the member if its status is alive
+      if member['Status'] == 1
+        peers += 1
+      end
+    end
+
     if peers < config[:min].to_i
       critical "[#{peers}] peers is below critical threshold of [#{config[:min]}]"
     elsif peers != config[:expected].to_i


### PR DESCRIPTION
This provides sensu checks for the status of consul cluster members in either the local cluster or the wan