### PR TITLE
Fixes for check-consul-service-health and check-service-consul (--all, --consul)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- Nothing
+- Fixed check-consul-service-health and check-service-consul --all argument @wg-tsuereth
+- check-consul-service-health and check-service-consul now accept a --consul argument to specify a server @wg-tsuereth
 
 ## [0.0.8] - 2016-04-03
 ### Added

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -37,6 +37,11 @@ require 'json'
 # Service Status
 #
 class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
+  option :consul,
+         description: 'consul server',
+         long: '--consul SERVER',
+         default: 'http://localhost:8500'
+
   option :service,
          description: 'a service managed by consul',
          short: '-s SERVICE',
@@ -51,7 +56,9 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
   # Get the service checks for the given service
   def acquire_service_data
     if config[:all]
-      Diplomat::Health.checks
+      Diplomat::Service.get_all.to_h.keys.each do |service|
+        Diplomat::Health.checks(service)
+      end
     else
       Diplomat::Health.checks(config[:service])
     end
@@ -59,6 +66,10 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
 
   # Do work
   def run
+    Diplomat.configure do |dc|
+      dc.url = config[:consul]
+    end
+
     warnings   = false
     criticals  = false
     checks     = {}

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -56,9 +56,7 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
   # Get the service checks for the given service
   def acquire_service_data
     if config[:all]
-      Diplomat::Service.get_all.to_h.keys.each do |service|
-        Diplomat::Health.checks(service)
-      end
+      Diplomat::Health.state('any')
     else
       Diplomat::Health.checks(config[:service])
     end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -55,9 +55,7 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   #
   def acquire_service_data
     if config[:all]
-      Diplomat::Service.get_all.to_h.keys.each do |service|
-        Diplomat::Health.checks(service)
-      end
+      Diplomat::Health.state('any')
     else
       Diplomat::Health.checks(config[:service])
     end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -35,6 +35,11 @@ require 'diplomat'
 # Service Status
 #
 class ServiceStatus < Sensu::Plugin::Check::CLI
+  option :consul,
+         description: 'consul server',
+         long: '--consul SERVER',
+         default: 'http://localhost:8500'
+
   option :service,
          description: 'a service managed by consul',
          short: '-s SERVICE',
@@ -50,7 +55,9 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   #
   def acquire_service_data
     if config[:all]
-      Diplomat::Health.checks
+      Diplomat::Service.get_all.to_h.keys.each do |service|
+        Diplomat::Health.checks(service)
+      end
     else
       Diplomat::Health.checks(config[:service])
     end
@@ -63,6 +70,10 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Main function
   #
   def run
+    Diplomat.configure do |dc|
+      dc.url = config[:consul]
+    end
+
     data = acquire_service_data
     passing = []
     failing = []


### PR DESCRIPTION
This resolves issues #14 and #15.

---

For both service-health checks:
* Adding a --consul argument for specifying Consul server by name:port
* Fixing the --all behavior to iterate over every available service -- which is slow, but actually works, whereas previous implementation was not supported by Diplomat