### PR TITLE
Adding --fail-if-not-found for the service health checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-consul-service-health and check-service-consul now accept a --fail-if-not-found argument @wg-tsuereth
 
 ## [1.0.0] - 2016-06-28
 ### Fixed

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -53,6 +53,11 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
          short: '-a',
          long: '--all'
 
+  option :fail_if_not_found,
+         description: 'fail if no service is found',
+         short: '-f',
+         long: '--fail-if-not-found'
+
   # Get the service checks for the given service
   def acquire_service_data
     if config[:all]
@@ -68,12 +73,14 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
       dc.url = config[:consul]
     end
 
+    found      = false
     warnings   = false
     criticals  = false
     checks     = {}
 
     # Process all of the nonpassing service checks
     acquire_service_data.each do |d|
+      found       = true
       checkId     = d['CheckID'] # rubocop:disable Style/VariableName
       checkStatus = d['Status'] # rubocop:disable Style/VariableName
 
@@ -86,6 +93,13 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
       criticals = true  if %w(critical unknown).include? checkStatus
     end
 
+    if config[:fail_if_not_found] && !found
+      msg = "Could not find checks for any services"
+      if config[:service]
+        msg = "Could not find checks for service #{config[:service]}"
+      end
+      critical msg
+    end
     critical checks if criticals
     warning checks  if warnings
     ok

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -94,7 +94,7 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
     end
 
     if config[:fail_if_not_found] && !found
-      msg = "Could not find checks for any services"
+      msg = 'Could not find checks for any services'
       if config[:service]
         msg = "Could not find checks for service #{config[:service]}"
       end

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -96,7 +96,7 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
     end
 
     if failing.empty? && passing.empty?
-      msg = "Could not find checks for any services"
+      msg = 'Could not find checks for any services'
       if config[:service]
         msg = "Could not find checks for service #{config[:service]}"
       end


### PR DESCRIPTION
If the meaning of `--fail-if-not-found` here is not clear, please let me know where this behavior should be documented.

Prior to this PR, `check-consul-service-health.rb` will emit UNKNOWN status if a requested service isn't found, while `check-service-consul.rb` will emit OK.  By default, this behavior is unchanged.

If the `--fail-if-not-found` option is specified, and if the requested service isn't found (or if `--all` is also specified and there are *no* services found), then CRITICAL will be emitted.

I personally find this function desirable to work around uncertainty with how services and checks are registered -- if I expect a service to be present, but it was never started (or was cleanly deregistered), Consul's checks won't indicate any problem.  The `--fail-if-not-found` option makes it explicit that Sensu should indicate failure if my requested service isn't currently registered.