### PR TITLE
Check for 'critical' instead of 'failing'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-service-consul should look for 'critical' instead of 'failing'
 
 ## [1.1.0] - 2016-08-03
 ### Added

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -92,7 +92,7 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
         'service' => d['ServiceName'],
         'service_id' => d['ServiceID'],
         'notes' => d['Notes']
-      } if d['Status'] == 'failing'
+      } if d['Status'] == 'critical'
     end
 
     if failing.empty? && passing.empty?


### PR DESCRIPTION
Looks like consul returns 'critical' instead of 'failing'