### PR TITLE
Adding a --tags filter for service health.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-consul-service-health and check-service-consul now accept a --tags filter @wg-tsuereth
 ### Fixed
 - check-service-consul should look for 'critical' instead of 'failing'
 

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -65,7 +65,7 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
 
   # Get the service checks for the given service
   def acquire_service_data
-    if config[:tags] and config[:service]
+    if config[:tags] && config[:service]
       tags = config[:tags].split(',').to_set
       services = []
       Diplomat::Health.service(config[:service]).each do |s|
@@ -83,7 +83,7 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
 
   # Do work
   def run
-    if config[:tags] and config[:all]
+    if config[:tags] && config[:all]
       critical 'Cannot specify --tags and --all simultaneously (Consul health/service/ versus health/state/).'
     end
 

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -46,8 +46,13 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
          long: '--service SERVICE',
          default: 'consul'
 
+  option :tags,
+         description: 'filter services by a comma-separated list of tags (requires --service)',
+         short: '-t TAGS',
+         long: '--tags TAGS'
+
   option :all,
-         description: 'get all services in a non-passing status',
+         description: 'get all services in a non-passing status (not compatible with --tags)',
          short: '-a',
          long: '--all'
 
@@ -59,7 +64,16 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Get the check data for the service from consul
   #
   def acquire_service_data
-    if config[:all]
+    if config[:tags] and config[:service]
+      tags = config[:tags].split(',').to_set
+      services = []
+      Diplomat::Health.service(config[:service]).each do |s|
+        if s['Service']['Tags'].to_set.superset? tags
+          services.push(*s['Checks'])
+        end
+      end
+      return services
+    elsif config[:all]
       Diplomat::Health.state('any')
     else
       Diplomat::Health.checks(config[:service])
@@ -73,6 +87,10 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Main function
   #
   def run
+    if config[:tags] and config[:all]
+      critical 'Cannot specify --tags and --all simultaneously (Consul health/service/ versus health/state/).'
+    end
+
     Diplomat.configure do |dc|
       dc.url = config[:consul]
     end
@@ -99,6 +117,9 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
       msg = 'Could not find checks for any services'
       if config[:service]
         msg = "Could not find checks for service #{config[:service]}"
+        if config[:tags]
+          msg += " with tags #{config[:tags]}"
+        end
       end
       if config[:fail_if_not_found]
         critical msg

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -64,7 +64,7 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Get the check data for the service from consul
   #
   def acquire_service_data
-    if config[:tags] and config[:service]
+    if config[:tags] && config[:service]
       tags = config[:tags].split(',').to_set
       services = []
       Diplomat::Health.service(config[:service]).each do |s|
@@ -87,7 +87,7 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
   # Main function
   #
   def run
-    if config[:tags] and config[:all]
+    if config[:tags] && config[:all]
       critical 'Cannot specify --tags and --all simultaneously (Consul health/service/ versus health/state/).'
     end
 


### PR DESCRIPTION
With `--service` and `--tags` options set, service-health checks can request service instances with specific tags in Consul.  (If multiple tags are specified in the `--tags` option, then all of them must be found in a service instance.)

If the tag filter results in no found services, `--fail-if-not-found` will return an error indicating as such.