### PR TITLE
Autodiscover and check all consul services running on the specified node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+## [1.4.0] 2017-08-05
+### Added
+- `check-consul-service-health` now accept a `--node` argument that will check all autodiscovered consul services running on the specified node (@psyhomb)
+
 ## [1.3.0] 2017-05-05
 ### Added
 - `check-consul-failures`, `check-consul-leader`, `check-consul-members`, and `check-consul-servers` now accept a --scheme parameter (@akatch)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Travis CI build pass

#### Improvement

`check-consul-service-health` now accept a `--node` argument that will check all autodiscovered consul services running on the specified node

#### Usage

```
# check-consul-service-health.rb -n node1.example.com

CheckConsulServiceHealth OK
```
```
# check-consul-service-health.rb -n node2.example.com

CheckConsulServiceHealth WARNING: [{"service:svc1"=>"ERROR: an unknown exception had occurred!\n", "Status"=>"warning"}, {"service:svc2"=>"ERROR: an unknown exception had occurred!\n", "Status"=>"warning"}]
```
Also I've added `Status` key so we can be sure which service exactly is in critical state
In this example we can clearly see that global state is critical, but also we can see that only svc1 is in critical state, and svc2 is in warning state
```
# check-consul-service-health.rb -n node3.example.com

CheckConsulServiceHealth CRITICAL: [{"service:svc1"=>"Get http://localhost:8080/healthcheck: dial tcp [::1]:8080: getsockopt: connection refused", "Status"=>"critical"}, {"service:svc2"=>"ERROR: an unknown exception had occurred!\n", "Status"=>"warning"}]
```