### PR TITLE
Use 'Service' key instead of 'ID' key for service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Bug fix for `check-consul-service-health` [#26](https://github.com/sensu-plugins/sensu-plugins-consul/pull/26) (@psyhomb)
+
 ### Added
 - ruby 2.4.1 testing (@majormoses)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+## [1.4.0] 2017-08-05
+### Added
+- `check-consul-service-health` now accept a `--node` argument that will check all autodiscovered consul services running on the specified node (@psyhomb)
+
 ## [1.3.0] 2017-05-05
 ### Added
 - `check-consul-failures`, `check-consul-leader`, `check-consul-members`, and `check-consul-servers` now accept a --scheme parameter (@akatch)

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -82,12 +82,12 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
     elsif config[:nodename]
       data = []
       begin
-        services = Diplomat::Node.get(config[:nodename]).Services.keys
+        services = Diplomat::Node.get(config[:nodename]).Services
       rescue
-        services = []
+        services = {}
       end
-      services.each do |service|
-        Diplomat::Health.checks(service).each do |check|
+      services.values.each do |service|
+        Diplomat::Health.checks(service['Service']).each do |check|
           data.push(check) if check.Node == config[:nodename]
         end
       end


### PR DESCRIPTION
Hi @majormoses,

I just discovered a bug in my previous PR [#25](https://github.com/sensu-plugins/sensu-plugins-consul/pull/25) that would cause for some services to be skipped during the check process, so I made another PR that's going to fix that.

Basically I was using a value of `ID` key as a service name and these two entities are not always the same, like you can see from this example, second service (svc2) has the same value for `ID` and `Service` key, which is not the case for the first one (svc1), in other words `Service` key is the key that we should rely upon, it will always hold a real service name and that's why we should use it instead of `ID` key for service discovery.

```json
# curl -s http://localhost:8500/v1/agent/services
{
    "svc1-prod": {
        "Address": "",
        "CreateIndex": 0,
        "EnableTagOverride": false,
        "ID": "svc1-prod",
        "ModifyIndex": 0,
        "Port": 8986,
        "Service": "svc1",
        "Tags": [
            "prod"
        ]
    },
    "svc2": {
        "Address": "",
        "CreateIndex": 0,
        "EnableTagOverride": false,
        "ID": "svc2",
        "ModifyIndex": 0,
        "Port": 8988,
        "Service": "svc2",
        "Tags": [
        ]
    }
}  
```