### PR TITLE
Added 'remove_failed_node' and 'critical' boolean options (check-consul-failures.rb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- `check-consul-failures` now accepts `--keep-failures` and `--critical` arguments (@psyhomb)
+
 ### Fixed
 - Bug fix for `check-consul-service-health` [#26](https://github.com/sensu-plugins/sensu-plugins-consul/pull/26) (@psyhomb)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Bug fix for `check-consul-service-health` [#26](https://github.com/sensu-plugins/sensu-plugins-consul/pull/26) (@psyhomb)
+
 ### Added
 - ruby 2.4.1 testing (@majormoses)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+## [1.4.0] 2017-08-05
+### Added
+- `check-consul-service-health` now accept a `--node` argument that will check all autodiscovered consul services running on the specified node (@psyhomb)
+
 ## [1.3.0] 2017-05-05
 ### Added
 - `check-consul-failures`, `check-consul-leader`, `check-consul-members`, and `check-consul-servers` now accept a --scheme parameter (@akatch)

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -82,12 +82,12 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
     elsif config[:nodename]
       data = []
       begin
-        services = Diplomat::Node.get(config[:nodename]).Services.keys
+        services = Diplomat::Node.get(config[:nodename]).Services
       rescue
-        services = []
+        services = {}
       end
-      services.each do |service|
-        Diplomat::Health.checks(service).each do |check|
+      services.values.each do |service|
+        Diplomat::Health.checks(service['Service']).each do |check|
           data.push(check) if check.Node == config[:nodename]
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass

#### Improvements

Added support for `--remove-failed-node` and `--critical` arguments in `check-consul-failures.rb`

Show warning if you find failed nodes
```
# check-consul-failures.rb --server consul-server.example.com

ConsulStatus WARNING: Found failed nodes: ["node1.example.com", "node2.example.com"]
```

Show critical if you find failed nodes
```
# check-consul-failures.rb --server consul-server.example.com --critical

ConsulStatus CRITICAL: Found failed nodes: ["node1.example.com", "node2.example.com"]
```

Remove all failing nodes
```
# check-consul-failures.rb --server consul-server.example.com --remove-failed-node

Removing failed node: node1.example.com
Removing failed node: node2.example.com
ConsulStatus OK: All clear
```

OK status
```
# check-consul-failures.rb --server consul-server.example.com

ConsulStatus OK: All nodes are alive
```