### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,7 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+# .match?() only exists in ruby 2.4+
+Performance/RegexpMatch:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
 ## [1.6.0] - 2017-09-30
 ### Added
 - `check-consul-leader`, `check-consul-members`, and `check-consul-servers` now accept `--insecure`, `--capath`, `--timeout` arguments (@akatch)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'
@@ -6,12 +8,12 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new

--- a/bin/check-consul-failures.rb
+++ b/bin/check-consul-failures.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # OUTPUT:
 #   plain text

--- a/bin/check-consul-kv-ttl.rb
+++ b/bin/check-consul-kv-ttl.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-kv-ttl
 #
@@ -126,8 +128,8 @@ class CheckConsulKvTTL < Sensu::Plugin::Check::CLI
           kv_status = kv_status.downcase
 
           # Flag based off of status
-          warning 'Warning status detected!'    if %w(warning).include? kv_status
-          critical 'Critical status detected!'  if %w(critical unknown).include? kv_status
+          warning 'Warning status detected!'    if %w[warning].include? kv_status
+          critical 'Critical status detected!'  if %w[critical unknown].include? kv_status
         end
 
         # Dig to the time
@@ -157,7 +159,7 @@ class CheckConsulKvTTL < Sensu::Plugin::Check::CLI
       critical "TTL Expired! Elapsed Time: #{elapsed_seconds}"                if elapsed_seconds > config[:critical]
       warning  "TTL Expiration Approaching! Elapsed Time: #{elapsed_seconds}" if elapsed_seconds > config[:warning]
       ok
-    rescue
+    rescue StandardError
       critical 'Unable to process DateTime objects!'
     end
   end

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-leader
 #
@@ -74,11 +76,11 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
   def valid_ip(ip)
     case ip.to_s
     when Resolv::IPv4::Regex
-      return true
+      true
     when Resolv::IPv6::Regex
-      return true
+      true
     else
-      return false
+      false
     end
   end
 

--- a/bin/check-consul-maintenance.rb
+++ b/bin/check-consul-maintenance.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-maintenance
 #

--- a/bin/check-consul-members.rb
+++ b/bin/check-consul-members.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-members
 #

--- a/bin/check-consul-servers.rb
+++ b/bin/check-consul-servers.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-servers
 #

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-consul-service-health
 #
@@ -78,20 +80,20 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
           services.push(*s['Checks'])
         end
       end
-      return services
+      services
     elsif config[:nodename]
       data = []
       begin
         services = Diplomat::Node.get(config[:nodename]).Services
-      rescue
+      rescue StandardError
         services = {}
       end
-      services.values.each do |service|
+      services.each_value do |service|
         Diplomat::Health.checks(service['Service']).each do |check|
           data.push(check) if check.Node == config[:nodename]
         end
       end
-      return data
+      data
     elsif config[:all]
       Diplomat::Health.state('any')
     else
@@ -128,8 +130,8 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
         'Status' => checkStatus
       )
 
-      warnings  = true  if %w(warning).include? checkStatus
-      criticals = true  if %w(critical unknown).include? checkStatus
+      warnings  = true  if %w[warning].include? checkStatus
+      criticals = true  if %w[critical unknown].include? checkStatus
     end
 
     if config[:fail_if_not_found] && !found

--- a/bin/check-service-consul.rb
+++ b/bin/check-service-consul.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-service-consul
 #
@@ -99,18 +101,21 @@ class ServiceStatus < Sensu::Plugin::Check::CLI
     passing = []
     failing = []
     data.each do |d|
-      passing << {
-        'node' => d['Node'],
-        'service' => d['ServiceName'],
-        'service_id' => d['ServiceID'],
-        'notes' => d['Notes']
-      } if d['Status'] == 'passing'
-      failing << {
-        'node' => d['Node'],
-        'service' => d['ServiceName'],
-        'service_id' => d['ServiceID'],
-        'notes' => d['Notes']
-      } if d['Status'] == 'critical'
+      if d['Status'] == 'passing'
+        passing << {
+          'node' => d['Node'],
+          'service' => d['ServiceName'],
+          'service_id' => d['ServiceID'],
+          'notes' => d['Notes']
+        }
+      elsif d['Status'] == 'critical'
+        failing << {
+          'node' => d['Node'],
+          'service' => d['ServiceName'],
+          'service_id' => d['ServiceID'],
+          'notes' => d['Notes']
+        }
+      end
     end
 
     if failing.empty? && passing.empty?

--- a/lib/sensu-plugins-consul.rb
+++ b/lib/sensu-plugins-consul.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-consul/version'

--- a/lib/sensu-plugins-consul/version.rb
+++ b/lib/sensu-plugins-consul/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsConsul
   module Version
     MAJOR = 1

--- a/sensu-plugins-consul.gemspec
+++ b/sensu-plugins-consul.gemspec
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 require_relative 'lib/sensu-plugins-consul'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'This plugin provides native instrumentation for monitoring Consul, including:
@@ -12,7 +14,7 @@ Gem::Specification.new do |s|
                               for passing/critical services.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-consul'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -24,12 +26,13 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1'
   s.summary                = 'Sensu plugins for Consul'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsConsul::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+
   s.add_runtime_dependency 'diplomat',     '0.14.0'
   s.add_runtime_dependency 'rest-client',  '1.8.0'
 
@@ -39,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Address CVE-2017-8418, see parent issue for details

#### Known Compatibility Issues
Removed ruby `< 2.1` support