### PR TITLE
Add checks to watch for impending loss of quorum and stale peer nodes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,7 @@ Style/Documentation:
 # .match?() only exists in ruby 2.4+
 Performance/RegexpMatch:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - test/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-consul-quorum.rb`: Check how many servers can be lost while maintaining quorum (@roboticcheese)
+- `check-consul-stale-peers.rb`: Check for stale peers in the raft configuration (@roboticcheese)
 
 ## [2.0.0] - 2018-03-07
 ### Security

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
  * bin/check-consul-members.rb
  * bin/check-service-consul.rb
  * bin/check-consul-maintenance.rb
+ * bin/check-consul-quorum.rb
+ * bin/check-consul-stale-peers.rb
 
 ## Usage
 

--- a/bin/check-consul-quorum.rb
+++ b/bin/check-consul-quorum.rb
@@ -1,0 +1,91 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: false
+
+#
+#   check-consul-quorum
+#
+# DESCRIPTION:
+#   This plugin checks how many nodes the cluster will be able to lose while
+#   still maintaining quorum.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   Connect to localhost, go critical when the cluster is at its minimum for
+#   quorum:
+#     ./check-consul-quorum
+#
+#   Connect to a remote Consul server over HTTPS:
+#     ./check-consul-quorum -s 192.168.42.42 -p 4443 -P https
+#
+#   Go critical when the cluster can lose one more server and keep quorum:
+#     ./check-consul-quorum -W 2 -C 1
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-consul/check/base'
+
+#
+# Consul quorum status
+#
+class ConsulQuorumStatus < SensuPluginsConsul::Check::Base
+  option :warning,
+         description: 'Warn when the cluster has this many spare servers ' \
+                      'beyond the minimum for quorum',
+         short: '-W NUMBER_OF_SPARE_SERVERS',
+         long: '--warning NUMBER_OF_SPARE_SERVERS',
+         proc: proc(&:to_i),
+         default: 1
+
+  option :critical,
+         description: 'Go critical when the cluster has this many spare ' \
+                      'servers beyond the minimum for quorum',
+         short: '-C NUMBER_OF_SPARE_SERVERS',
+         long: '--critical NUMBER_OF_SPARE_SERVERS',
+         proc: proc(&:to_i),
+         default: 0
+
+  def run
+    raft = consul_get('operator/raft/configuration')
+    members = consul_get('agent/members')
+
+    total = raft['Servers'].select { |s| s['Voter'] == true }.length
+    required = total / 2 + 1
+    alive = members.select do |m|
+      m.key?('Tags') && m['Tags']['role'] == 'consul' && m['Status'] == 1
+    end.length
+
+    spares = alive - required
+
+    msg = "Cluster has #{alive}/#{total} servers alive and"
+    msg = if spares < 0
+            "#{msg} has lost quorum"
+          elsif spares.zero?
+            "#{msg} has the minimum required for quorum"
+          else
+            "#{msg} can lose #{spares} more without losing quorum"
+          end
+
+    if spares < 0 || spares <= config[:critical]
+      critical msg
+    elsif spares <= config[:warning]
+      warning msg
+    else
+      ok msg
+    end
+  end
+end

--- a/bin/check-consul-stale-peers.rb
+++ b/bin/check-consul-stale-peers.rb
@@ -1,0 +1,73 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: false
+
+#
+#   check-consul-stale-peers
+#
+# DESCRIPTION:
+#   This plugin checks the raft configuration for stale ("unknown") peers.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   Connect to localhost, go critical when there are any stale peers:
+#     ./check-consul-stale-peers
+#
+#   Connect to a remote Consul server over HTTPS:
+#     ./check-consul-stale-peers -s 192.168.42.42 -p 4443 -P https
+#
+#   Go critical when the cluster has two or more stale peers:
+#     ./check-consul-stale-peers -W 1 -C 2
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-consul/check/base'
+
+#
+# Consul stale peers
+#
+class ConsulStalePeers < SensuPluginsConsul::Check::Base
+  option :warning,
+         description: 'Warn when there are this many stale peers',
+         short: '-W NUMBER_OF_PEERS',
+         long: '--warning NUMBER_OF_PEERS',
+         proc: proc(&:to_i),
+         default: 1
+
+  option :critical,
+         description: 'Go critical when there are this many stale peers',
+         short: '-C NUMBER_OF_PEERS',
+         long: '--critical NUMBER_OF_PEERS',
+         proc: proc(&:to_i),
+         default: 1
+
+  def run
+    raft = consul_get('operator/raft/configuration')
+
+    res = raft['Servers'].select { |s| s['Node'] == '(unknown)' }.length
+
+    msg = "Cluster contains #{res} stale peer#{'s' unless res == 1}"
+
+    if res >= config[:critical]
+      critical msg
+    elsif res >= config[:warning]
+      warning msg
+    else
+      ok msg
+    end
+  end
+end

--- a/lib/sensu-plugins-consul/check/base.rb
+++ b/lib/sensu-plugins-consul/check/base.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: false
+
+#
+#   sensu-plugins-consul/check/base
+#
+# DESCRIPTION:
+#   This class defines some of the common config options and helper methods for
+#   other Consul plugins to use.
+#
+# OUTPUT:
+#   N/A
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   Import this file and create subclasses of the included plugin class.
+#     require 'sensu-plugins-consul/check/base'
+#     class ConsulTestStatus < SensuPluginsConsul::Check::Base
+#       ...
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'json'
+require 'rest-client'
+require 'sensu-plugin/check/cli'
+
+#
+# Consul shared base plugin
+#
+module SensuPluginsConsul
+  class Check
+    class Base < Sensu::Plugin::Check::CLI
+      option :server,
+             description: 'Consul server',
+             short: '-s SERVER',
+             long: '--server SERVER',
+             default: '127.0.0.1'
+
+      option :port,
+             description: 'Consul HTTP port',
+             short: '-p PORT',
+             long: '--port PORT',
+             proc: proc(&:to_i),
+             default: 8500
+
+      option :protocol,
+             description: 'Consul listener protocol',
+             short: '-P PROTOCOL',
+             long: '--protocol PROTOCOL',
+             in: %w[http https],
+             default: 'http'
+
+      option :insecure,
+             description: 'Set this flag to disable SSL verification',
+             short: '-k',
+             long: '--insecure',
+             boolean: true,
+             default: false
+
+      option :capath,
+             description: 'Absolute path to an alternative CA file',
+             short: '-c CAPATH',
+             long: '--capath CAPATH'
+
+      option :timeout,
+             description: 'Connection will time out after this many seconds',
+             short: '-t TIMEOUT_IN_SECONDS',
+             long: '--timeout TIMEOUT_IN_SECONDS',
+             proc: proc(&:to_i),
+             default: 5
+
+      #
+      # Fetch and return the parsed JSON data from a specified Consul API endpoint.
+      #
+      def consul_get(endpoint)
+        url = "#{config[:protocol]}://#{config[:server]}:#{config[:port]}/" \
+              "v1/#{endpoint}"
+        options = { timeout: config[:timeout],
+                    verify_ssl: !config[:insecure],
+                    ssl_ca_file: config[:capath] }
+
+        JSON.parse(RestClient::Resource.new(url, options).get)
+      rescue Errno::ECONNREFUSED
+        critical 'Consul is not responding'
+      rescue RestClient::RequestTimeout
+        critical 'Consul connection timed out'
+      rescue RestClient::Exception => e
+        unknown "Consul returned: #{e}"
+      end
+    end
+  end
+end

--- a/test/bin/check-consul-quorum_spec.rb
+++ b/test/bin/check-consul-quorum_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+#
+# check-consul-quorum_spec
+#
+# DESCRIPTION:
+#   Tests for check-consul-quorum.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-consul-quorum.rb'
+
+describe ConsulQuorumStatus do
+  let(:config) { [] }
+  let(:check) { described_class.new(config) }
+
+  describe '#run' do
+    let(:raft) { nil }
+    let(:members) { nil }
+
+    before do
+      expect(check).to receive(:consul_get).with('operator/raft/configuration')
+                                           .and_return(raft)
+      expect(check).to receive(:consul_get).with('agent/members')
+                                           .and_return(members)
+    end
+
+    context 'a 3/3 healthy cluster' do
+      let(:raft) do
+        {
+          'Servers' => [
+            {
+              'ID' => '1.2.3.4:8300',
+              'Node' => 'ip-1-2-3-4',
+              'Address' => '1.2.3.4:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.5:8300',
+              'Node' => 'ip-1-2-3-5',
+              'Address' => '1.2.3.5:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.6:8300',
+              'Node' => 'ip-1-2-3-6',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => true,
+              'Voter' => true
+            }
+          ]
+        }
+      end
+      let(:members) do
+        [
+          {
+            'Name' => 'ip-1-2-3-4',
+            'Addr' => '1.2.3.4',
+            'Port' => 8301,
+            'Tags' => {
+              'dc' => 'testing',
+              'port' => '8300',
+              'role' => 'consul'
+            },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-5',
+            'Addr' => '1.2.3.5',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-6',
+            'Addr' => '1.2.3.6',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-44',
+            'Addr' => '1.2.3.44',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'node' },
+            'Status' => 1
+          }
+        ]
+      end
+
+      context 'a default config' do
+        it 'returns a warning' do
+          expect(check.run).to eq('WARNING: Cluster has 3/3 servers alive ' \
+                                  'and can lose 1 more without losing quorum')
+        end
+      end
+
+      context 'a config to return critical at one spare' do
+        let(:config) { %w[-C 1] }
+
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster has 3/3 servers alive ' \
+                                  'and can lose 1 more without losing quorum')
+        end
+      end
+
+      context 'a config to return ok at one spare' do
+        let(:config) { %w[-W 0 -C 0] }
+
+        it 'returns an ok' do
+          expect(check.run).to eq('OK: Cluster has 3/3 servers alive ' \
+                                  'and can lose 1 more without losing quorum')
+        end
+      end
+    end
+
+    context 'a 2/3 degraded cluster' do
+      let(:raft) do
+        {
+          'Servers' => [
+            {
+              'ID' => '1.2.3.4:8300',
+              'Node' => 'ip-1-2-3-4',
+              'Address' => '1.2.3.4:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.5:8300',
+              'Node' => 'ip-1-2-3-5',
+              'Address' => '1.2.3.5:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.6:8300',
+              'Node' => 'ip-1-2-3-6',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => true,
+              'Voter' => true
+            }
+          ]
+        }
+      end
+      let(:members) do
+        [
+          {
+            'Name' => 'ip-1-2-3-4',
+            'Addr' => '1.2.3.4',
+            'Port' => 8301,
+            'Tags' => {
+              'dc' => 'testing',
+              'port' => '8300',
+              'role' => 'consul'
+            },
+            'Status' => 4
+          },
+          {
+            'Name' => 'ip-1-2-3-5',
+            'Addr' => '1.2.3.5',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-6',
+            'Addr' => '1.2.3.6',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-44',
+            'Addr' => '1.2.3.44',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'node' },
+            'Status' => 1
+          }
+        ]
+      end
+
+      context 'a default config' do
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster has 2/3 servers alive ' \
+                                  'and has the minimum required for quorum')
+        end
+      end
+
+      context 'a config to return warning at no spares' do
+        let(:config) { %w[-W 0 -C -1] }
+
+        it 'returns a warning' do
+          expect(check.run).to eq('WARNING: Cluster has 2/3 servers alive ' \
+                                  'and has the minimum required for quorum')
+        end
+      end
+
+      context 'a config to return ok at no spares' do
+        let(:config) { %w[-W -1 -C -1] }
+
+        it 'returns an ok' do
+          expect(check.run).to eq('OK: Cluster has 2/3 servers alive ' \
+                                  'and has the minimum required for quorum')
+        end
+      end
+    end
+
+    context 'a 1/3 failed cluster' do
+      let(:raft) do
+        {
+          'Servers' => [
+            {
+              'ID' => '1.2.3.4:8300',
+              'Node' => 'ip-1-2-3-4',
+              'Address' => '1.2.3.4:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.5:8300',
+              'Node' => 'ip-1-2-3-5',
+              'Address' => '1.2.3.5:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.6:8300',
+              'Node' => 'ip-1-2-3-6',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => false,
+              'Voter' => true
+            }
+          ]
+        }
+      end
+      let(:members) do
+        [
+          {
+            'Name' => 'ip-1-2-3-4',
+            'Addr' => '1.2.3.4',
+            'Port' => 8301,
+            'Tags' => {
+              'dc' => 'testing',
+              'port' => '8300',
+              'role' => 'consul'
+            },
+            'Status' => 4
+          },
+          {
+            'Name' => 'ip-1-2-3-5',
+            'Addr' => '1.2.3.5',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 4
+          },
+          {
+            'Name' => 'ip-1-2-3-6',
+            'Addr' => '1.2.3.6',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'consul' },
+            'Status' => 1
+          },
+          {
+            'Name' => 'ip-1-2-3-44',
+            'Addr' => '1.2.3.44',
+            'Port' => 8301,
+            'Tags' => { 'role' => 'node' },
+            'Status' => 1
+          }
+        ]
+      end
+
+      context 'a default config' do
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster has 1/3 servers alive ' \
+                                  'and has lost quorum')
+        end
+      end
+
+      context 'a config to return warning at -1 spares' do
+        let(:config) { %w[-W -1 -C -2] }
+
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster has 1/3 servers alive ' \
+                                  'and has lost quorum')
+        end
+      end
+
+      context 'a config to return ok at -1 spares' do
+        let(:config) { %w[-W -2 -C -3] }
+
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster has 1/3 servers alive ' \
+                                  'and has lost quorum')
+        end
+      end
+    end
+  end
+end

--- a/test/bin/check-consul-stale-peers_spec.rb
+++ b/test/bin/check-consul-stale-peers_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+#
+# check-consul-stale-peers_spec
+#
+# DESCRIPTION:
+#   Tests for check-consul-stale-peers.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-consul-stale-peers.rb'
+
+describe ConsulStalePeers do
+  let(:config) { [] }
+  let(:check) { described_class.new(config) }
+
+  describe '#run' do
+    let(:raft) { nil }
+
+    before do
+      expect(check).to receive(:consul_get).with('operator/raft/configuration')
+                                           .and_return(raft)
+    end
+
+    context 'a healthy cluster' do
+      let(:raft) do
+        {
+          'Servers' => [
+            {
+              'ID' => '1.2.3.4:8300',
+              'Node' => 'ip-1-2-3-4',
+              'Address' => '1.2.3.4:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.5:8300',
+              'Node' => 'ip-1-2-3-5',
+              'Address' => '1.2.3.5:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.6:8300',
+              'Node' => 'ip-1-2-3-6',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => true,
+              'Voter' => true
+            }
+          ]
+        }
+      end
+
+      context 'a default config' do
+        it 'returns an ok' do
+          expect(check.run).to eq('OK: Cluster contains 0 stale peers')
+        end
+      end
+    end
+
+    context 'a cluster with a stale peer' do
+      let(:raft) do
+        {
+          'Servers' => [
+            {
+              'ID' => '1.2.3.4:8300',
+              'Node' => 'ip-1-2-3-4',
+              'Address' => '1.2.3.4:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.5:8300',
+              'Node' => 'ip-1-2-3-5',
+              'Address' => '1.2.3.5:8300',
+              'Leader' => false,
+              'Voter' => true
+            },
+            {
+              'ID' => '1.2.3.6:8300',
+              'Node' => 'ip-1-2-3-6',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => true,
+              'Voter' => true
+            },
+            {
+              'ID' => 'blargh',
+              'Node' => '(unknown)',
+              'Address' => '1.2.3.6:8300',
+              'Leader' => false,
+              'Voter' => true
+            }
+          ]
+        }
+      end
+
+      context 'a default config' do
+        it 'returns a critical' do
+          expect(check.run).to eq('CRITICAL: Cluster contains 1 stale peer')
+        end
+      end
+
+      context 'a config to return warning at one stale peer' do
+        let(:config) { %w[-C 2] }
+
+        it 'returns a warning' do
+          expect(check.run).to eq('WARNING: Cluster contains 1 stale peer')
+        end
+      end
+
+      context 'a config to return ok at one stale peer' do
+        let(:config) { %w[-W 2 -C 3] }
+
+        it 'returns an ok' do
+          expect(check.run).to eq('OK: Cluster contains 1 stale peer')
+        end
+      end
+    end
+  end
+end

--- a/test/lib/sensu-plugins-consul/check/base_spec.rb
+++ b/test/lib/sensu-plugins-consul/check/base_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#
+#   sensu-plugins-consul/check/base_spec
+#
+# DESCRIPTION:
+#   Tests for SensuPluginsConsul::Check::Base
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2018, Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../../../spec_helper.rb'
+require_relative '../../../../lib/sensu-plugins-consul/check/base'
+
+describe SensuPluginsConsul::Check::Base do
+  let(:config) { [] }
+  let(:check) { described_class.new(config) }
+
+  describe '#consul_get' do
+    context 'a default config' do
+      before do
+        expect(RestClient::Resource).to receive(:new)
+          .with('http://127.0.0.1:8500/v1/things',
+                timeout: 5,
+                verify_ssl: true,
+                ssl_ca_file: nil)
+          .and_return(double(get: '{"some":"json"}'))
+      end
+
+      it 'fetches the appropriate URL' do
+        expect(check.consul_get('things')).to eq('some' => 'json')
+      end
+    end
+
+    context 'a custom HTTPS config' do
+      let(:config) { %w[-s 1.2.3.4 -P https -p 4443 -c /etc/ca --insecure] }
+
+      before do
+        expect(RestClient::Resource).to receive(:new)
+          .with('https://1.2.3.4:4443/v1/things',
+                timeout: 5,
+                verify_ssl: false,
+                ssl_ca_file: '/etc/ca')
+          .and_return(double(get: '{"some":"json"}'))
+      end
+
+      it 'fetches the appropriate URL' do
+        expect(check.consul_get('things')).to eq('some' => 'json')
+      end
+    end
+
+    context 'a connection refused error' do
+      before do
+        expect(RestClient::Resource).to receive(:new)
+          .and_raise(Errno::ECONNREFUSED)
+      end
+
+      it 'returns a critical' do
+        res = check.consul_get('/things')
+        expect(res).to eq('CRITICAL: Consul is not responding')
+      end
+    end
+
+    context 'a request timeout error' do
+      before do
+        expect(RestClient::Resource).to receive(:new)
+          .and_raise(RestClient::RequestTimeout)
+      end
+
+      it 'returns a critical' do
+        res = check.consul_get('/things')
+        expect(res).to eq('CRITICAL: Consul connection timed out')
+      end
+    end
+
+    context 'some other REST exception' do
+      before do
+        expect(RestClient::Resource).to receive(:new)
+          .and_raise(RestClient::Exception)
+      end
+
+      it 'returns a critical' do
+        res = check.consul_get('/things')
+        expect(res).to eq('UNKNOWN: Consul returned: RestClient::Exception: ')
+      end
+    end
+  end
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,33 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
+
+RSpec.configure do |c|
+  c.before do
+    # Give Sensu's at_exit code something to run that's not a real plugin.
+    Sensu::Plugin::CLI.class_eval do
+      # PluginStub
+      class PluginStub
+        def run; end
+
+        def ok(*); end
+
+        def warning(*); end
+
+        def critical(*); end
+
+        def unknown(*); end
+      end
+      class_variable_set(:@@autorun, PluginStub)
+    end
+
+    # Stub every status method to return a string instead of exiting.
+    %i[ok warning critical unknown].each do |status|
+      allow_any_instance_of(Sensu::Plugin::CLI).to receive(status) do |_, val|
+        "#{status.upcase}: #{val}"
+      end
+    end
+  end
+end
+
 CodeClimate::TestReporter.start


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

It is not.

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

Live tests (done on a cluster with five live servers, one failed server, and one stale peer):

```bash
$ check-consul-quorum.rb
ConsulQuorumStatus WARNING: Cluster has 5/7 servers alive and can lose 1 more without losing quorum

$ check-consul-quorum.rb -W 2 -C 1
ConsulQuorumStatus CRITICAL: Cluster has 5/7 servers alive and can lose 1 more without losing quorum

$ check-consul-quorum.rb -W 0 -C 0
ConsulQuorumStatus OK: Cluster has 5/7 servers alive and can lose 1 more without losing quorum

$ check-consul-stale-peers.rb
ConsulStalePeers CRITICAL: Cluster contains 1 stale peer

$ check-consul-stale-peers.rb -W 1 -C 2
ConsulStalePeers WARNING: Cluster contains 1 stale peer

$ check-consul-stale-peers.rb -W 2 -C 3
ConsulStalePeers OK: Cluster contains 1 stale peer
```

#### Purpose

We recently had to go through a Consul outage recovery on a cluster that, it
turned out, had been slowly accumulating stale peers in its raft configuration
until it no longer had enough for quorum and died.

The `check-consul-stale-peers` check would examine the raft config for peers
that have gone stale ("(unknown)") while the `check-consul-quorum` check would
monitor how many servers a cluster can lose while still maintaining quorum.

#### Known Compatibility Issues

N/A