### PR TITLE
check-consul-leader.rb timeout option need to be an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- `check-consul-leader.rb`: Timeout option must be an integer (@scalp42)
 
 ## [2.1.0] - 2018-03-29
 ### Added

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -97,7 +97,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
   end
 
   def run
-    options = { timeout: config[:timeout],
+    options = { timeout: config[:timeout].to_i,
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
                 ssl_ca_file: (config[:capath] if defined? config[:capath]) }
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/status/leader"

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -71,6 +71,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          description: 'connection will time out after this many seconds',
          short: '-t TIMEOUT_IN_SECONDS',
          long: '--timeout TIMEOUT_IN_SECONDS',
+         proc: proc { |t| t.to_i },
          default: 5
 
   def valid_ip(ip)
@@ -97,7 +98,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
   end
 
   def run
-    options = { timeout: config[:timeout].to_i,
+    options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
                 ssl_ca_file: (config[:capath] if defined? config[:capath]) }
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/status/leader"


### PR DESCRIPTION
Hi folks,

When using the timeout param:

```
root@ip-10-62-207-28:~# /opt/sensu/embedded/bin/check-consul-leader.rb -t 5
Check failed to run: can't convert String into time interval, ["/opt/sensu/embedded/lib/ruby/2.4.0/net/protocol.rb:176:in `wait_readable'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/protocol.rb:176:in `rbuf_fill'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/protocol.rb:154:in `readuntil'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/protocol.rb:164:in `readline'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http/response.rb:40:in `read_status_line'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http/response.rb:29:in `read_new'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:1446:in `block in transport_request'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:1443:in `catch'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:1443:in `transport_request'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:1416:in `request'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/request.rb:270:in `net_http_do_request'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/request.rb:418:in `block in transmit'", "/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:877:in `start'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/request.rb:413:in `transmit'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/request.rb:176:in `execute'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/request.rb:41:in `execute'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-1.8.0/lib/restclient/resource.rb:51:in `get'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-consul-2.1.0/bin/check-consul-leader.rb:105:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```

After:

```
root@ip-10-62-207-28:~# /opt/sensu/embedded/bin/check-consul-leader.rb -t 5
ConsulStatus OK: Consul is UP and has a leader
```

Thanks! 💅 