### PR TITLE
fix consul-check-failures 405s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- check-consul-failures: use a put when requesting to remove a node from the agent api (@majormoses)
+
 ## [2.2.0] - 2018-06-11
 ### Added
 - add ACL support to all consul checks (@scalp42)

--- a/bin/check-consul-failures.rb
+++ b/bin/check-consul-failures.rb
@@ -81,7 +81,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
             "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/agent/force-leave/#{node['Name']}",
             timeout: 5,
             headers: { 'X-Consul-Token' => config[:token] }
-          ).get
+          ).put
           nodes_names.delete(node['Name'])
         end
         ok 'All clear' if nodes_names.empty?


### PR DESCRIPTION
We are using a get when it should be a put.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

fixes #40 

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Fix broken script resulting in 405 method not allowed when attempting to remove failing clients

#### Known Compatibility Issues
none